### PR TITLE
ctf06 최종

### DIFF
--- a/pages/ctf06.py
+++ b/pages/ctf06.py
@@ -38,7 +38,7 @@ st.header("🔒 [CTF06] 수상한 이메일 전송 시스템")
 st.write("### 📜")
 
 st.write(f"안녕하세요 사원 `{nickname}`님!")
-st.write("LLL 컴퍼니는 사원 여러분들을 위해, 사내 업무를 자동화를 위한 AI 비서 :blue[FastMiller]📨를 도입했습니다!")
+st.write("LLL 컴퍼니는 💼사원 여러분들을 위해, 사내 업무를 자동화를 위한 AI 비서 :blue[FastMiller]📨를 도입했습니다!")
 st.write(":blue[FastMiller]📨는 이메일 전송 요청을 스스로 해석하여 작업을 수행할 수 있습니다.")  
 st.write(":blue[FastMiller]📨가 어떤 요청까지 처리할 수 있는지 테스트해보고, 위험한 명령을 통해 flag를 획득하세요!")
 
@@ -52,7 +52,7 @@ st.markdown("## 🧠 프롬프트 입력")
 
 # 프롬프트 제출 섹션
 user_input = st.text_area("📨 이메일 전송 요청 입력하기", placeholder="예: 김남석 부장님께 '12시에 긴급 회의 잡혔습니다'라고 이메일 보내줘")
-image_file = st.file_uploader("🌐 첨부할 이미지가 있으신가요? (:red[.jpng, .png, .jpg 파일만 허용])", type=None)
+image_file = st.file_uploader("🌐 첨부할 이미지가 있으신가요? (:red[.jpeg, .png, .jpg 파일만 허용])", type=None)
 
 
 

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -297,7 +297,7 @@ def ctf06_check_top_admin(user_api_key, image_file=None):
     """ 6번 과도한 에이전시 관리자 권한 검증 """
     file_ext = None  
     encoded_image = None
-    ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/jpeg"]
+    ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/jpg"]
     if image_file is not None:
         # image_file.type은 Streamlit이 자동 추론한 MIME
         file_ext = image_file.type

--- a/utils/ui.py
+++ b/utils/ui.py
@@ -63,6 +63,7 @@ def render_flag_sub(challenge_id: str):
     }).execute()
 
     st.session_state[f"{challenge_id}_solved"] = True
+    st.balloons()
     st.success(f"✅ 정답입니다! {row['points']}점 획득")
     st.write(f"🏅 총점: **{total_score(user['id'])}**")
 


### PR DESCRIPTION
**개요**
오타 수정 및 입력받는 파일 타입 변경

**변경점**
어떤 작업들이 이루어졌는지 모두 기술해주세요.
1. ctf06에서 입력받을 수 있는 파일 파입 -> none으로 설정하고 별도로 Mime 검사
2. 별도로 mime 검사하고 미지원 파일과 파일이 들어오지 않았을 경우 구분해서 에러 메세지 출력
3. 오타 수정

**추가 내용**
더 설명할 내용이 있다면 적어주세요.